### PR TITLE
Changes Part 1

### DIFF
--- a/src/markehme/factionsplus/FactionsPlusListener.java
+++ b/src/markehme/factionsplus/FactionsPlusListener.java
@@ -132,10 +132,9 @@ public class FactionsPlusListener implements Listener {
         	        Utilities.removePower(p, FactionsPlus.config.getDouble("extraPowerLossIfDeathByPotion"));
         	        return;
           }
-          if((causeOfDeath == "CUSTOM" && 
-        		  	(FactionsPlus.config.getDouble("extraPowerLossIfDeathByOther") > 0)) {
-					Utilities.removePower(p, FactionsPlus.config.getDouble("extraPowerLossIfDeathByOther"));
-					return;
+          if(FactionsPlus.config.getDouble("extraPowerLossIfDeathByOther") > 0) {
+			Utilities.removePower(p, FactionsPlus.config.getDouble("extraPowerLossIfDeathByOther"));
+			return;
       }
     }
 


### PR DESCRIPTION
Fixed powerboost handling: brackets were incorrect and would have cancelled everything except the first two events
Fixed return; statements to make more sense: placing them inside the causeofdeath statements instead of the if(config option) statements allows for certain things to happen: if you're checking on pvp kills for instance, you'll both want to remove power from dead player and add power to killer.
I'm not sure about suicide handling: I'm pretty sure there is a causeofdeath="SUICIDE" for bukkit, might be wrong though.
Removed a duplicate function.
