### PR TITLE
Leader and Officer able to do all commands

### DIFF
--- a/src/me/markeh/factionsframework/command/requirements/ReqPlayerIsOfficer
+++ b/src/me/markeh/factionsframework/command/requirements/ReqPlayerIsOfficer
@@ -1,0 +1,22 @@
+package me.markeh.factionsframework.command.requirements;
+
+import me.markeh.factionsframework.command.FactionsCommand;
+
+public class ReqPlayerIsOfficer extends Requirement {
+	
+	private static ReqPlayerIsOfficer i;
+	public static ReqPlayerIsOfficer get() {
+		if (i == null) i = new ReqPlayerIsOfficer();
+		return i;
+	}
+	
+	@Override
+	public boolean isMet(FactionsCommand command) {
+		if (command.fplayer == null || ! command.fplayer.isOfficer()) {
+			command.sender.sendMessage(command.colourise("<reset><red>This command can <bold>only<reset><red> be run from officer rank!"));
+			return false;
+		}
+		
+		return true;
+	}
+}

--- a/src/me/markeh/factionsplus/commands/CmdAddRule.java
+++ b/src/me/markeh/factionsplus/commands/CmdAddRule.java
@@ -25,6 +25,8 @@ public class CmdAddRule extends FactionsCommand {
 		
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.rules", Texts.get().cmdAddRule_noPermission)));
 	}
 	

--- a/src/me/markeh/factionsplus/commands/CmdAnnounce.java
+++ b/src/me/markeh/factionsplus/commands/CmdAnnounce.java
@@ -21,6 +21,8 @@ public class CmdAnnounce extends FactionsCommand {
 		
 		this.addRequirement(ReqIsPlayer.get());
 		this.addRequirement(ReqHasFaction.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.announce", Texts.get().cmdAnnounce_noPermission)));
 
 		this.setErrorOnTooManyArgs(false);

--- a/src/me/markeh/factionsplus/commands/CmdChest.java
+++ b/src/me/markeh/factionsplus/commands/CmdChest.java
@@ -30,6 +30,8 @@ public class CmdChest  extends FactionsCommand {
 		
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.chests", "You don't have permission to uses faction chests.")));
 
 	}

--- a/src/me/markeh/factionsplus/commands/CmdDelRule.java
+++ b/src/me/markeh/factionsplus/commands/CmdDelRule.java
@@ -18,6 +18,8 @@ public class CmdDelRule extends FactionsCommand {
 		
 		this.addRequirement(ReqIsPlayer.get());
 		this.addRequirement(ReqHasFaction.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.rules", Texts.get().cmdAddRule_noPermission)));
 
 	}

--- a/src/me/markeh/factionsplus/commands/CmdJail.java
+++ b/src/me/markeh/factionsplus/commands/CmdJail.java
@@ -25,6 +25,8 @@ public class CmdJail extends FactionsCommand {
 		
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.jail", Texts.get().cmdJail_noPermission)));
 
 	}

--- a/src/me/markeh/factionsplus/commands/CmdRemoveWarp.java
+++ b/src/me/markeh/factionsplus/commands/CmdRemoveWarp.java
@@ -19,6 +19,8 @@ public class CmdRemoveWarp extends FactionsCommand {
 				
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.managewarps", "You don't have permission to remove warps.")));
 
 	}

--- a/src/me/markeh/factionsplus/commands/CmdRules.java
+++ b/src/me/markeh/factionsplus/commands/CmdRules.java
@@ -18,6 +18,8 @@ public class CmdRules extends FactionsCommand {
 		
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.rules", Texts.get().cmdRules_noPermission)));
 
 	}

--- a/src/me/markeh/factionsplus/commands/CmdSetJail.java
+++ b/src/me/markeh/factionsplus/commands/CmdSetJail.java
@@ -27,6 +27,8 @@ public class CmdSetJail extends FactionsCommand {
 				
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.jail", Texts.get().cmdSetJail_noPermission)));
 	}
 	

--- a/src/me/markeh/factionsplus/commands/CmdSetWarp.java
+++ b/src/me/markeh/factionsplus/commands/CmdSetWarp.java
@@ -22,6 +22,8 @@ public class CmdSetWarp extends FactionsCommand {
 				
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.setwarp", "You don't have permission to set warps!")));
 
 	}

--- a/src/me/markeh/factionsplus/commands/CmdUnjail.java
+++ b/src/me/markeh/factionsplus/commands/CmdUnjail.java
@@ -26,6 +26,8 @@ public class CmdUnjail extends FactionsCommand {
 				
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.jail", Texts.get().cmdUnjail_noPermission)));
 
 	}

--- a/src/me/markeh/factionsplus/commands/CmdWarp.java
+++ b/src/me/markeh/factionsplus/commands/CmdWarp.java
@@ -25,6 +25,8 @@ public class CmdWarp extends FactionsCommand {
 		
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.warp", "You don't have permission to do that.")));
 
 	}

--- a/src/me/markeh/factionsplus/commands/CmdWarps.java
+++ b/src/me/markeh/factionsplus/commands/CmdWarps.java
@@ -18,6 +18,8 @@ public class CmdWarps extends FactionsCommand {
 						
 		this.addRequirement(ReqHasFaction.get());
 		this.addRequirement(ReqIsPlayer.get());
+		this.addRequirement(ReqIsLeader.get());
+		this.addRequirement(ReqIsOfficer.get());
 		this.addRequirement(ReqPermission.get(Perm.get("factionsplus.warp", "You don't have permission to do that.")));
 
 	}


### PR DESCRIPTION
**1st Option:**
Only a Leader or Officer can execute this command, this way people don't have to make special ranks outside of Factions.

This way you can have everybody with the permission: factionsplus.setwarp
And only the Leader and Officer is able to set the warp.

**2nd Option:**
Create a section in the config 'access' ??

e.g.:

Access:
  SetWarp:
    - Leader
  SetJail:
    - Leader
    - Officer